### PR TITLE
Fix pods liveness and readiness probes

### DIFF
--- a/thumbor/thumbor.yml
+++ b/thumbor/thumbor.yml
@@ -89,26 +89,26 @@ spec:
         livenessProbe:
           # an http probe
           httpGet:
-            path: /unsafe/20x20/smart/https%3A%2F%2Fs3-eu-west-1.amazonaws.com%2Fpingdom-test%2Ftest-image.png
+            path: /healthcheck
             port: 80
           # length of time to wait for a pod to initialize
           # after pod startup, before applying health checking
-          initialDelaySeconds: 10
-          timeoutSeconds: 10
+          initialDelaySeconds: 45
+          timeoutSeconds: 5
           successThreshold: 1
-          failureThreshold: 1
+          failureThreshold: 3
           periodSeconds: 30
         readinessProbe:
           # an http probe
           httpGet:
-            path: /unsafe/20x20/smart/https%3A%2F%2Fs3-eu-west-1.amazonaws.com%2Fpingdom-test%2Ftest-image.png
+            path: /healthcheck
             port: 80
           # length of time to wait for a pod to initialize
           # after pod startup, before applying health checking
           initialDelaySeconds: 10
-          timeoutSeconds: 10
+          timeoutSeconds: 5
           successThreshold: 1
-          failureThreshold: 1
+          failureThreshold: 3
           periodSeconds: 10
         ports:
         - containerPort: 80


### PR DESCRIPTION
Set liveness and readiness probes' http path as the [official chart](https://github.com/cloudposse/charts/blob/master/incubator/thumbor/values.yaml#L101-L118) does.
Also tweaking some other probes' configuration parameters.

Note that the replaced image path `/unsafe/20x20/smart/https%3A%2F%2Fs3-eu-west-1.amazonaws.com%2Fpingdom-test%2Ftest-image.png` is still valid, but only to be used by pingdom; from the perspective of the kubelet it makes no sense to use the "full" check chain including network and AWS services.

Fix https://git.smarpsocial.com/smarpers/smarpshare/-/issues/10642